### PR TITLE
Fix VOS ICAO: Rovos Air → Volaris El Salvador

### DIFF
--- a/airlines.dat
+++ b/airlines.dat
@@ -4230,7 +4230,7 @@
 4236,Rotormotion,,,RKT,ROCKET,United Kingdom,N
 4237,Rotterdam Jet Center,,,JCR,ROTTERDAM JETCENTER,Netherlands,N
 4238,Rover Airways International,,,ROV,ROVERAIR,United States,N
-4239,Rovos Air,,,VOS,ROVOS,South Africa,N
+4239,Volaris El Salvador,,,VOS,VOLSAL,El Salvador,Y
 4240,Royal Air Cargo,,,RCG,ROYAL CARGO,South Africa,N
 4241,Royal Air Force,,RR,RFR,RAFAIR,United Kingdom,N
 4242,Royal Air Force of Oman,,RS,MJN,MAJAN,Oman,N

--- a/airlines.json
+++ b/airlines.json
@@ -9655,7 +9655,7 @@
 ,
 {"id":"4238","name":"Rover Airways International","alias":"","iata":"","icao":"ROV","callsign":"ROVERAIR","country":"United States","active":"N"}
 ,
-{"id":"4239","name":"Rovos Air","alias":"","iata":"","icao":"VOS","callsign":"ROVOS","country":"South Africa","active":"N"}
+{"id":"4239","name":"Volaris El Salvador","alias":"","iata":"","icao":"VOS","callsign":"VOLSAL","country":"El Salvador","active":"Y"}
 ,
 {"id":"4240","name":"Royal Air Cargo","alias":"","iata":"","icao":"RCG","callsign":"ROYAL CARGO","country":"South Africa","active":"N"}
 ,


### PR DESCRIPTION
## Summary

Fixes #21.

VOS ICAO was outdated — it pointed to Rovos Air (South Africa, inactive). It is now assigned to Volaris El Salvador (El Salvador, active).

Changes:
- `airlines.json` + `airlines.dat`: update `name`, `callsign`, `country`, and `active` fields for the VOS entry